### PR TITLE
Addressing SEO indexing

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -29,4 +29,5 @@ sectionTitle: Latest news
 sectionLeft: true
 video: /images/video/HomeMixFinal2.mp4
 videoPoster: /images/video/homepage-video-placeholder.jpg
+canonical: https://www.dragonfly.co.nz/
 ---

--- a/content/pages/404.html
+++ b/content/pages/404.html
@@ -1,13 +1,10 @@
 ---
 title: 404
+canonical: https://www.dragonfly.co.nz/pages/404.html
 ---
 
 <header
-  class="
-    page-header page-header--small page-header--article
-    bg-light-peach
-    math-paper
-  "
+  class="page-header page-header--small page-header--article bg-light-peach math-paper"
 >
   <div class="page-header__outer">
     <div class="page-header--article__text page-header--article__text--news">

--- a/content/publications/lanfear_partitionfinder_2017.md
+++ b/content/publications/lanfear_partitionfinder_2017.md
@@ -3,6 +3,7 @@ pdf: lanfear_partitionfinder_2017.pdf
 title: "PartitionFinder 2: new methods for selecting partitioned models of evolution for molecular and morphological phylogenetic analyses"
 tags: brett, philosophy, article
 ---
+
 PartitionFinder 2 is a program for automatically selecting best-fit partitioning schemes and models of evolution for phylogenetic analyses. PartitionFinder 2 is substantially faster and more efficient than version 1, and incorporates many new methods and features. These include the ability to analyze morphological datasets, new methods to analyze genome-scale datasets, new output formats to facilitate interoperability with downstream software, and many new models of molecular evolution.
 
-PartitionFinder 2 is freely available under an open source license and works on Windows, OSX, and Linux operating systems. It can be downloaded from [www.robertlanfear.com/partitionfinder/](www.robertlanfear.com/partitionfinder/). The source code is available at [https://github.com/brettc/partitionfinder](https://github.com/brettc/partitionfinder).
+PartitionFinder 2 is freely available under an open source license and works on Windows, OSX, and Linux operating systems. It can be downloaded from [https://www.robertlanfear.com/partitionfinder/](www.robertlanfear.com/partitionfinder/). The source code is available at [https://github.com/brettc/partitionfinder](https://github.com/brettc/partitionfinder).

--- a/content/templates/default.html
+++ b/content/templates/default.html
@@ -44,7 +44,11 @@
     <meta name="description" content="$description$" />
     $else$ $if(og-description)$
     <meta name="description" content="$og-description$" />
-    $endif$ $endif$
+    $endif$ $endif$ $if(canonical)$
+    <link rel="canonical" href="$canonical$" />
+    $else$
+    <link rel="canonical" href="https://www.dragonfly.co.nz$url$" />
+    $endif$
     <!-- Google tag (gtag.js) -->
     <script
       async


### PR DESCRIPTION
**Details**

A number of urls in our site point to the same url (i.e. when we have errors or appending query params to filter the publications pages). Google sees these as duplicates & makes a guess as to what is the canonical url.

**Result**

I have added a canonical link to the header of the base template. In combination with a `canonical` frontmatter field in the markdown, we can modify the canonical url. If no `canonical` field is supplied, will use the `$url$` field instead.

I've attempted to resolve the errors seen here: https://search.google.com/search-console/index?resource_id=https://www.dragonfly.co.nz/&pages=ALL_URLS

I've also updated s3's redirect rules & changed all 403 responses in the bucket (i.e. you don't have access to the object) to 404 responses via CloudFront.

---

closes #406