### PR TITLE
corrections to the summaries of newly-added publications

### DIFF
--- a/content/publications/berkenbusch_intertidal_2024.md
+++ b/content/publications/berkenbusch_intertidal_2024.md
@@ -33,20 +33,20 @@ In contrast, the lowest total cockle density was at Umupuia Beach, estimated at 
 cockles per m<sup>2</sup>.  
 
 At the same time, Umupuia Beach was the only site with a high proportion and relatively high density of 
-large individuals (≥30 mm shell length). At this beach, large cockles made up over 50% of the population, 
+large individuals (&ge;30 mm shell length). At this beach, large cockles made up over 50% of the population, 
 and occurred at an estimated density of 71 (CV: 22.23%) large cockles per m<sup>2</sup>. Other cockle populations 
 contained few large individuals, and their density estimates were markedly lower, typically with high 
 uncertainty (including CV values above 40%).  
 
 Length-frequency distributions documented the prevalence of medium-sized cockles 
 (sizes >15 mm and <30 mm shell length) across the northern populations. This size class largely 
-determined the population size structure with varying proportions of recruits (≤15 mm shell length) 
+determined the population size structure with varying proportions of recruits (&le;15 mm shell length) 
  contributing to the population overall. In 2023--24, the proportion of recruits varied between 19 and 63%   
  at most sites (i.e., excepting Umupuia Beach), reflecting a marked influx of individuals to existing cockle populations.  
 
 Pipi populations were surveyed at ten of the northern sites. Their total population sizes ranged from  
 0.45  (CV: 15.66%) million pipi at Marsden Bank to 121.15 (CV: 13.48%) million individuals at Ruakākā  Estuary.  
-The highest density estimate was also at Ruakākā  Estuary  
+The highest density estimate was also at Ruakākā  Estuary 
 with 5857 individuals per m<sup>2</sup>, largely 
 caused by a significant recruitment event. The only other site with high pipi 
 densities was Te Mata Bay, where this species exceeded 1000 individuals
@@ -55,7 +55,7 @@ The lowest density estimates
  were at Whangateau Harbour and Raglan Harbour, at 20 individuals per m<sup>2</sup> 
  and 27 individuals per m<sup>2</sup>, respectively. 
  
-Few of the pipi populations contained notable numbers of large pipi  (≥50 mm shell length), and 
+Few of the pipi populations contained notable numbers of large pipi  (&ge;50 mm shell length), and 
 estimates for this size class frequently had high uncertainty. The only site where estimates for large pipi 
  had low uncertainty (i.e., a CV of less than 20%) was  Te Mata Bay. At this site,  
  over 10% of the total population consisted of large individuals, and their estimated density was  
@@ -65,7 +65,7 @@ The general scarcity of large-sized pipi was also evident in the length-frequenc
 which were dominated by the medium pipi size class (>20 mm and <50 mm shell length), 
 forming a strong cohort in unimodal populations.  Exceptions to this population size structure
 were three of the four Northland sites, where substantial recruitment led to the prevalence of recruits 
- (≤20 mm shell length) 
+ (&le;20 mm shell length) 
 in the populations.  At Te Haumi Bay, Ruakākā Estuary, and Marsden Bank, the proportion of
  recruits varied from 75  to 87%. At Marsden Bank, the strong recruitment indicated some population 
  recovery, following the loss of the pipi population in \mbox{2021--22}. 
@@ -74,7 +74,7 @@ Sediment in the cockle strata was characterised by a low organic content (less t
 fractions. The most prevalent grain sizes were fine sand (grain size >125 μm), 
 followed by medium and very fine sands (>250 and >63 μm).   A number of 
 sites had relatively high proportions of sediment fines 
-(silt and clay; ≤63 μm grain size), which may impact 
+(silt and clay; &le;63 μm grain size), which may impact 
 suspension-feeding cockles through increased 
 sediment resuspension.   These sites were 
 Ngunguru Estuary, Raglan Harbour, Tairua Harbour, Te Haumi Bay, and Umupuia Beach, where  

--- a/content/publications/berkenbusch_intertidal_2024.md
+++ b/content/publications/berkenbusch_intertidal_2024.md
@@ -2,27 +2,26 @@
 pdf: berkenbusch_intertidal_2024.pdf
 tags: katrin, tyla, fisheries, dragonfly, benthic, report, shellfish
 ---
-Recreational and customary fishing is culturally important in New Zealand, including the take of
-marine species in coastal environments. Two of the main target species in these non-commercial 
-fisheries are cockle (*Austrovenus stutchburyi*) and  pipi (*Paphies australis*), which occur throughout the 
- country, often in close proximity to urban centres. This accessibility means that both species are 
-vulnerable to overexploitation, and their presence in coastal environments makes them also susceptible 
-to other human impacts.   
+Recreational and customary fishing is culturally important in New Zealand, including the take of 
+marine species in coastal environments. Two of the main target species in these non-commercial fisheries are 
+cockle (*Austrovenus stutchburyi*) and pipi (*Paphies australis*), which occur throughout 
+the country, often in close proximity to urban centres. This accessibility means that both species are 
+vulnerable to overexploitation, and their presence in coastal environments makes them also susceptible  
+to other human impacts. 
 
+To monitor cockle and pipi populations in northern New Zealand, Fisheries New Zealand initiated regular population assessments 
+in the early 1990s. Following refinements and the spatial extension of this programme, the intertidal surveys  
+currently assess bivalve populations 
+at a range of sites in Auckland, Northland, Waikato, and Bay of Plenty.  The surveys collect demographic data  
+ and document population trends across the northern North Island regions. 
 
-To monitor cockle and pipi populations in northern New Zealand, Fisheries New Zealand initiated 
-regular population assessments in the early 1990s. Following refinements and the spatial extension of 
-this programme, the intertidal surveys currently assess bivalve populations at a range of sites in 
-Auckland, Northland, Waikato, and Bay of Plenty. The surveys collect demographic data and document 
-population trends across the northern North Island regions. 
-
-This study presents the findings from the most recent survey in the northern North Island monitoring 
-series, providing data from the 2023–24 fishing year. The survey sites were (in alphabetical order): 
-Bowentown Beach, Little Waihi Estuary, Mangawhai Harbour, Marsden Bank, Ngunguru Estuary, 
-Raglan Harbour, Ruakākā Estuary, Tairua Harbour, Te Haumi Bay, Te Mata Bay (Waipatukahu), 
-Umupuia Beach, and Whangateau Harbour. At five of the sites, Marsden Bank, Ngunguru Estuary, Te 
-Mata Bay, Umupuia Beach, and Whangateau Harbour, existing fishery restrictions prevent the take of 
-cockles and pipi.  
+This study presents the findings from the most recent survey in the northern North Island monitoring series, 
+providing data from the 
+2023–24 fishing year. The survey sites were (in alphabetical order): Bowentown Beach, Little Waihi 
+Estuary, Mangawhai Harbour, Marsden Bank, Ngunguru Estuary, Raglan Harbour, Ruakākā Estuary, 
+Tairua Harbour, Te Haumi Bay, Te Mata Bay (Waipatukahu), Umupuia Beach, and Whangateau Harbour.  
+At five of the sites, Marsden Bank, Ngunguru Estuary, Te Mata Bay, Umupuia  Beach, and Whangateau 
+Harbour, existing fishery restrictions prevent the take of cockles and pipi. 
 
 Nine of the 2023–24 sites contained cockle populations, which varied in total abundance and density, 
 depending on the site. The highest total population abundance was at Whangateau Harbour with an 
@@ -34,54 +33,68 @@ In contrast, the lowest total cockle density was at Umupuia Beach, estimated at 
 cockles per m<sup>2</sup>.  
 
 At the same time, Umupuia Beach was the only site with a high proportion and relatively high density of 
-large individuals (30 mm shell length). At this beach, large cockles made up over 50% of the population, 
+large individuals (≥30 mm shell length). At this beach, large cockles made up over 50% of the population, 
 and occurred at an estimated density of 71 (CV: 22.23%) large cockles per m<sup>2</sup>. Other cockle populations 
 contained few large individuals, and their density estimates were markedly lower, typically with high 
 uncertainty (including CV values above 40%).  
 
-Length-frequency distributions documented the prevalence of medium-sized cockles (sizes >15 mm and 
-<30 mm shell length) across the northern populations. This size class largely determined the population 
-size structure with varying proportions of recruits (15 mm shell length) contributing to the population 
-overall. In 2023–24, the proportion of recruits varied between 19 and 63% at most sites (i.e., excepting 
-Umupuia Beach), reflecting a marked influx of individuals to existing cockle populations.  
+Length-frequency distributions documented the prevalence of medium-sized cockles 
+(sizes >15 mm and <30 mm shell length) across the northern populations. This size class largely 
+determined the population size structure with varying proportions of recruits (≤15 mm shell length) 
+ contributing to the population overall. In 2023--24, the proportion of recruits varied between 19 and 63%   
+ at most sites (i.e., excepting Umupuia Beach), reflecting a marked influx of individuals to existing cockle populations.  
 
-Pipi populations were surveyed at ten of the northern sites. Their total population sizes ranged from 0.45 
-(CV: 15.66%) million pipi at Marsden Bank to 121.15 (CV: 13.48%) million individuals at Ruakākā 
-Estuary. The highest density estimate was also at Ruakākā Estuary with 5857 individuals per m2, largely 
-caused by a significant recruitment event. The only other site with high pipi densities was Te Mata Bay, 
-where this species exceeded 1000 individuals per m<sup>2</sup>. The lowest density estimates were at Whangateau 
-Harbour and Raglan Harbour, at 20 individuals per m<sup>2</sup> and 27 individuals per m<sup>2</sup>, respectively. 
+Pipi populations were surveyed at ten of the northern sites. Their total population sizes ranged from  
+0.45  (CV: 15.66%) million pipi at Marsden Bank to 121.15 (CV: 13.48%) million individuals at Ruakākā  Estuary.  
+The highest density estimate was also at Ruakākā  Estuary  
+with 5857 individuals per m<sup>2</sup>, largely 
+caused by a significant recruitment event. The only other site with high pipi 
+densities was Te Mata Bay, where this species exceeded 1000 individuals
+ per m<sup>2</sup>. 
+The lowest density estimates
+ were at Whangateau Harbour and Raglan Harbour, at 20 individuals per m<sup>2</sup> 
+ and 27 individuals per m<sup>2</sup>, respectively. 
+ 
+Few of the pipi populations contained notable numbers of large pipi  (≥50 mm shell length), and 
+estimates for this size class frequently had high uncertainty. The only site where estimates for large pipi 
+ had low uncertainty (i.e., a CV of less than 20%) was  Te Mata Bay. At this site,  
+ over 10% of the total population consisted of large individuals, and their estimated density was  
+ 171 (CV: 12.79%) large pipi per m<sup>2</sup>.  
+  
+The general scarcity of large-sized pipi was also evident in the length-frequency distributions, 
+which were dominated by the medium pipi size class (>20 mm and <50 mm shell length), 
+forming a strong cohort in unimodal populations.  Exceptions to this population size structure
+were three of the four Northland sites, where substantial recruitment led to the prevalence of recruits 
+ (≤20 mm shell length) 
+in the populations.  At Te Haumi Bay, Ruakākā Estuary, and Marsden Bank, the proportion of
+ recruits varied from 75  to 87%. At Marsden Bank, the strong recruitment indicated some population 
+ recovery, following the loss of the pipi population in \mbox{2021--22}. 
 
-Few of the pipi populations contained notable numbers of large pipi (50 mm shell length), and estimates 
-for this size class frequently had high uncertainty. The only site where estimates for large pipi had low 
-uncertainty (i.e., a CV of less than 20%) was Te Mata Bay. At this site, over 10% of the total population 
-consisted of large individuals, and their estimated density was 171 (CV: 12.79%) large pipi per m<sup>2</sup>. 
+Sediment in the cockle strata was characterised by a low organic content (less than 3%) and varying proportions of grain size 
+fractions. The most prevalent grain sizes were fine sand (grain size >125 μm), 
+followed by medium and very fine sands (>250 and >63 μm).   A number of 
+sites had relatively high proportions of sediment fines 
+(silt and clay; ≤63 μm grain size), which may impact 
+suspension-feeding cockles through increased 
+sediment resuspension.   These sites were 
+Ngunguru Estuary, Raglan Harbour, Tairua Harbour, Te Haumi Bay, and Umupuia Beach, where  
+average proportions of sediment fines were between  8  and 10%. Individual samples at Umupuia Beach 
+exceeded 
+60% of sediment in this grain size fraction. 
 
-The general scarcity of large-sized pipi was also evident in the length-frequency distributions, which were 
-dominated by the medium pipi size class (>20 mm and <50 mm shell length), forming a strong cohort in 
-unimodal populations. Exceptions to this population size structure were three of the four Northland sites, 
-where substantial recruitment led to the prevalence of recruits (20 mm shell length) in the populations. 
-At Te Haumi Bay, Ruakākā Estuary, and Marsden Bank, the proportion of recruits varied from 75 to 
-87%. At Marsden Bank, the strong recruitment indicated some population recovery, following the loss 
-of the pipi population in 2021–22. 
+Sediment data were also used to explore the relationship between sediment 
+grain size fractions and cockle abundance,
+based on principal component analysis. General patterns from this data exploration 
+indicated that cockle abundance was generally associated with fine sand size fractions, 
+but less so with sediment fines. 
 
-Sediment in the cockle strata was characterised by a low organic content (less than 3%) and varying 
-proportions of grain size fractions. The most prevalent grain sizes were fine sand (grain size >125 μm), 
-followed by medium and very fine sands (>250 and >63 μm). A number of sites had relatively high 
-proportions of sediment fines (silt and clay; 63 μm grain size), which may impact suspension-feeding 
-cockles through increased sediment resuspension. These sites were Ngunguru Estuary, Raglan Harbour, 
-Tairua Harbour, Te Haumi Bay, and Umupuia Beach, where average proportions of sediment fines were 
-between 8 and 10%. Individual samples at Umupuia Beach exceeded 60% of sediment in this grain size 
-fraction. 
-
-Sediment data were also used to explore the relationship between sediment grain size fractions and cockle 
-abundance, based on principal component analysis. General patterns from this data exploration indicated 
-that cockle abundance was generally associated with fine sand size fractions, but less so with sediment 
-fines.  Cockle population data were also used in geostatistical models to examine spatio-temporal trends in 
-predicted cockle densities at the survey sites. This analysis allowed the identification of high-density 
-areas within cockle strata, and assessment of changes in these “hotspots” over time. At most of the survey 
-sites, the locations of high-density areas were comparable between the total population and large cockles, 
-although hotspots were typically more restricted for the latter populations. At some sites, Umupuia Beach, 
-Tairua Harbour, and Te Haumi Bay, distinct high-density areas in early surveys became smaller and less 
-pronounced over time. In contrast, three sites were characterised by areas of high cockle densities that 
-persisted over time, Bowentown Beach, Ngunguru Estuary and Raglan Harbour. 
+Cockle population data were also used in geostatistical models to examine 
+spatio-temporal trends in predicted cockle densities at the survey sites.  This 
+analysis allowed the identification of high-density areas within cockle strata, and 
+assessment of changes in 
+these "hotspots"  over time. At most of the survey sites, the locations of high-density areas were 
+comparable between the total population and large 
+cockles, although hotspots were typically more restricted for the latter populations. At some sites, 
+Umupuia Beach, Tairua Harbour,  and Te Haumi Bay, distinct high-density areas in early surveys became 
+smaller and less pronounced over time. In contrast, three sites were characterised by areas of 
+high cockle densities that persisted over time, Bowentown Beach, Ngunguru Estuary and Raglan Harbour.

--- a/content/publications/berkenbusch_intertidal_2024.md
+++ b/content/publications/berkenbusch_intertidal_2024.md
@@ -32,44 +32,8 @@ had similar high-density estimates (>1000 individuals per m<sup>2</sup>), Ngungu
 In contrast, the lowest total cockle density was at Umupuia Beach, estimated at 132 (CV: 19.47%)
 cockles per m<sup>2</sup>.
 
-<<<<<<< HEAD
-At the same time, Umupuia Beach was the only site with a high proportion and relatively high density of 
-large individuals (&ge;30 mm shell length). At this beach, large cockles made up over 50% of the population, 
-and occurred at an estimated density of 71 (CV: 22.23%) large cockles per m<sup>2</sup>. Other cockle populations 
-contained few large individuals, and their density estimates were markedly lower, typically with high 
-uncertainty (including CV values above 40%).  
-
-Length-frequency distributions documented the prevalence of medium-sized cockles 
-(sizes >15 mm and <30 mm shell length) across the northern populations. This size class largely 
-determined the population size structure with varying proportions of recruits (&le;15 mm shell length) 
- contributing to the population overall. In 2023--24, the proportion of recruits varied between 19 and 63%   
- at most sites (i.e., excepting Umupuia Beach), reflecting a marked influx of individuals to existing cockle populations.  
-
-Pipi populations were surveyed at ten of the northern sites. Their total population sizes ranged from  
-0.45  (CV: 15.66%) million pipi at Marsden Bank to 121.15 (CV: 13.48%) million individuals at Ruakākā  Estuary.  
-The highest density estimate was also at Ruakākā  Estuary 
-with 5857 individuals per m<sup>2</sup>, largely 
-caused by a significant recruitment event. The only other site with high pipi 
-densities was Te Mata Bay, where this species exceeded 1000 individuals
- per m<sup>2</sup>. 
-The lowest density estimates
- were at Whangateau Harbour and Raglan Harbour, at 20 individuals per m<sup>2</sup> 
- and 27 individuals per m<sup>2</sup>, respectively. 
- 
-Few of the pipi populations contained notable numbers of large pipi  (&ge;50 mm shell length), and 
-estimates for this size class frequently had high uncertainty. The only site where estimates for large pipi 
- had low uncertainty (i.e., a CV of less than 20%) was  Te Mata Bay. At this site,  
- over 10% of the total population consisted of large individuals, and their estimated density was  
- 171 (CV: 12.79%) large pipi per m<sup>2</sup>.  
-  
-The general scarcity of large-sized pipi was also evident in the length-frequency distributions, 
-which were dominated by the medium pipi size class (>20 mm and <50 mm shell length), 
-forming a strong cohort in unimodal populations.  Exceptions to this population size structure
-were three of the four Northland sites, where substantial recruitment led to the prevalence of recruits 
- (&le;20 mm shell length) 
-=======
 At the same time, Umupuia Beach was the only site with a high proportion and relatively high density of
-large individuals (≥30 mm shell length). At this beach, large cockles made up over 50% of the population,
+large individuals (≥30 mm shell length). At this beach, large cockles made up over 50% of the population,
 and occurred at an estimated density of 71 (CV: 22.23%) large cockles per m<sup>2</sup>. Other cockle populations
 contained few large individuals, and their density estimates were markedly lower, typically with high
 uncertainty (including CV values above 40%).
@@ -77,7 +41,7 @@ uncertainty (including CV values above 40%).
 Length-frequency distributions documented the prevalence of medium-sized cockles
 (sizes >15 mm and <30 mm shell length) across the northern populations. This size class largely
 determined the population size structure with varying proportions of recruits (≤15 mm shell length)
-contributing to the population overall. In 2023--24, the proportion of recruits varied between 19 and 63%
+contributing to the population overall. In 2023-24, the proportion of recruits varied between 19 and 63%
 at most sites (i.e., excepting Umupuia Beach), reflecting a marked influx of individuals to existing cockle populations.
 
 Pipi populations were surveyed at ten of the northern sites. Their total population sizes ranged from
@@ -101,24 +65,10 @@ which were dominated by the medium pipi size class (>20 mm and <50 mm shell leng
 forming a strong cohort in unimodal populations.  Exceptions to this population size structure
 were three of the four Northland sites, where substantial recruitment led to the prevalence of recruits
  (≤20 mm shell length)
->>>>>>> beb422ba942c4e035221bc461a94a977c439a049
 in the populations.  At Te Haumi Bay, Ruakākā Estuary, and Marsden Bank, the proportion of
  recruits varied from 75  to 87%. At Marsden Bank, the strong recruitment indicated some population
- recovery, following the loss of the pipi population in \mbox{2021--22}.
+ recovery, following the loss of the pipi population in 2021-22.
 
-<<<<<<< HEAD
-Sediment in the cockle strata was characterised by a low organic content (less than 3%) and varying proportions of grain size 
-fractions. The most prevalent grain sizes were fine sand (grain size >125 μm), 
-followed by medium and very fine sands (>250 and >63 μm).   A number of 
-sites had relatively high proportions of sediment fines 
-(silt and clay; &le;63 μm grain size), which may impact 
-suspension-feeding cockles through increased 
-sediment resuspension.   These sites were 
-Ngunguru Estuary, Raglan Harbour, Tairua Harbour, Te Haumi Bay, and Umupuia Beach, where  
-average proportions of sediment fines were between  8  and 10%. Individual samples at Umupuia Beach 
-exceeded 
-60% of sediment in this grain size fraction. 
-=======
 Sediment in the cockle strata was characterised by a low organic content (less than 3%) and varying proportions of grain size
 fractions. The most prevalent grain sizes were fine sand (grain size >125 μm),
 followed by medium and very fine sands (>250 and >63 μm). A number of
@@ -130,7 +80,6 @@ Ngunguru Estuary, Raglan Harbour, Tairua Harbour, Te Haumi Bay, and Umupuia Beac
 average proportions of sediment fines were between  8  and 10%. Individual samples at Umupuia Beach
 exceeded
 60% of sediment in this grain size fraction.
->>>>>>> beb422ba942c4e035221bc461a94a977c439a049
 
 Sediment data were also used to explore the relationship between sediment
 grain size fractions and cockle abundance,

--- a/content/publications/doeweler_linking_2024.md
+++ b/content/publications/doeweler_linking_2024.md
@@ -3,13 +3,15 @@ pdf: doeweler_linking_2024.md
 tags: fabian, bayesian, geospatial, ecology, article
 ---
 Unravelling slow ecosystem migration patterns requires a fundamental understanding  
-of the broad-scale climatic drivers, which are further modulated by fine-scale heterogeneities just 
- outside established ecosystem boundaries. While modern Unoccupied Aerial Vehicle (UAV) remote  
-sensing approaches enable us to monitor local scale ecotone dynamics in unprecedented detail, they  
-are often underutilised as a temporal snapshot of the conditions on site. In this study in the Southern  
-Alps of New Zealand, we demonstrate how the combination of multispectral and thermal data, as 
-well as LiDAR data (2019), supplemented by three decades (1991–2021) of treeline transect data can   
-add great value to field monitoring campaigns by putting seedling regeneration patterns at treeline  
+of the broad-scale climatic drivers, which are further modulated by fine-scale 
+heterogeneities just outside established ecosystem boundaries. While modern 
+Unoccupied Aerial Vehicle (UAV) remote sensing approaches enable us to 
+monitor local scale ecotone dynamics in unprecedented detail, they are often 
+underutilised as a temporal snapshot of the conditions on site. In this study in 
+the Southern  Alps of New Zealand, we demonstrate how the combination of 
+multispectral and thermal data, as well as LiDAR data (2019), supplemented 
+by three decades (1991–2021) of treeline transect data can add great value 
+to field monitoring campaigns by putting seedling regeneration patterns at treeline  
 into a spatially explicit context.  
 
 Orthorectification and mosaicking of RGB and multispectral imagery  

--- a/content/publications/middleton_video_2024.md
+++ b/content/publications/middleton_video_2024.md
@@ -3,10 +3,42 @@ pdf: middleton_video_2024.pdf
 tags: edward, fishery, bycatch, dragonfly, report
 ---
 
-Video observation was used to monitor seabird captures in the Fisheries Management Area (FMA) 1bottom-longline fishery. The observations were made during the 2020–21 and 2021–22 fishing years,from November 2020 to May 2022. This programme (typically referred to as the 'petrel project')extended previous video monitoring of this fishery that began during the 2016–17 fishing year. Existingcamera deployments, on eight voluntarily participating vessels, were used to collect the footage. Theparticipating vessels set 35% of the total hooks in FMA 1 bottom longline fisheries during 2020–21,and 40% of the total hooks in these fisheries during 2021–22. The statutory Electronic Reporting (ER)data were used to define haul periods, and hauls were randomly selected for video review. Any haulsthat had fisher-reported captures were also selected for review. There were also a small number of haulsthat were reviewed for other reasons. Overall, for the 2021 summer season (November 2020 to May2021), 441 (12.1%) of bottom longline fishing events in FMA 1 were reviewed, and for the 2022summer season 211 events (8%) were reviewed. Additionally, 252 (3.7%) of bottom longline fishingevents occurring from June to October 2021 were reviewed.
+Video observation was used to monitor seabird captures in the Fisheries Management Area (FMA) 1
+bottom-longline fishery. The observations were made during the 2020–21 and 2021–22 fishing years, 
+from November 2020 to May 2022. This programme (typically referred to as the 'petrel project') 
+extended previous video monitoring of this fishery that began during the 2016–17 fishing year. Existing 
+camera deployments, on eight voluntarily participating vessels, were used to collect the footage. The 
+participating vessels set 35% of the total hooks in FMA 1 bottom longline fisheries during 2020–21, 
+and 40% of the total hooks in these fisheries during 2021–22. The statutory Electronic Reporting (ER) 
+data were used to define haul periods, and hauls were randomly selected for video review. Any hauls 
+that had fisher-reported captures were also selected for review. There were also a small number of hauls 
+that were reviewed for other reasons. Overall, for the 2021 summer season (November 2020 to May 
+2021), 441 (12.1%) of bottom longline fishing events in FMA 1 were reviewed, and for the 2022 
+summer season 211 events (8%) were reviewed. Additionally, 252 (3.7%) of bottom longline fishing 
+events occurring from June to October 2021 were reviewed. 
 
-If any seabird captures were found during the primary review, the capture events were passed to anexpert reviewer for further review. There were a total of five reviewers reviewing footage from the2020–21 fishing year. In addition, during the 2021 fishing year, any hauls with capture events werepassed for secondary review from at least three other reviewers. This allowed variation in the skill ofthe reviewers at detecting seabird captures to be quantified. Based on expert review of the videofootage, there were 176 seabird captures during 2021, and 21 during 2022. Around a third of theseabird captures were dead (26.7% of captures during 2021, and 66.7% of captures during 2022). Thehighest number of captures recorded from a single vessel was 71 captures. Flesh-footed shearwater(*Ardenna carneipes*) was the most frequently caught species (139 captures during 2021, and 19captures during 2022), followed by black petrel (*Procellaria parkinsoni*; 35 captures during 2021, and2 captures during 2022). A fluttering shearwater (*Puffinus gavia*) and a sooty shearwater (*Ardennagrisea*) were also captured, both in 2021. The secondary reviewing established that there was highvariation in reviewer skill. Two reviewers detected over 90% of the seabird captures; however, onereviewer detected fewer than 50% of the captures.
+If any seabird captures were found during the primary review, the capture events were passed to an 
+expert reviewer for further review. There were a total of five reviewers reviewing footage from the 
+2020–21 fishing year. In addition, during the 2021 fishing year, any hauls with capture events were 
+passed for secondary review from at least three other reviewers. This allowed variation in the skill of 
+the reviewers at detecting seabird captures to be quantified. Based on expert review of the video 
+footage, there were 176 seabird captures during 2021, and 21 during 2022. Around a third of the 
+seabird captures were dead (26.7% of captures during 2021, and 66.7% of captures during 2022). The 
+highest number of captures recorded from a single vessel was 71 captures. Flesh-footed shearwater 
+(*Ardenna carneipes*) was the most frequently caught species (139 captures during 2021, and 19 
+captures during 2022), followed by black petrel (*Procellaria parkinsoni*; 35 captures during 2021, and 
+2 captures during 2022). A fluttering shearwater (*Puffinus gavia*) and a sooty shearwater (*Ardenna 
+grisea*) were also captured, both in 2021. The secondary reviewing established that there was high 
+variation in reviewer skill. Two reviewers detected over 90% of the seabird captures; however, one 
+reviewer detected fewer than 50% of the captures. 
 
-A model was used to estimate the total captures of black petrels and flesh footed shearwaters using thevideo-review data. There were an estimated 40 (97.5% c.i.: 14 to 79) black petrel captures in all bottomlongline fishing in FMA 1 during the 2021–22 fishing year, and an estimated 159 (97.5% c.i.: 56 to 392)flesh-footed shearwater captures in the same fisheries and period.
+A model was used to estimate the total captures of black petrels and flesh footed shearwaters using the
+video-review data. There were an estimated 40 (97.5% c.i.: 14 to 79) black petrel captures in all bottom
+longline fishing in FMA 1 during the 2021–22 fishing year, and an estimated 159 (97.5% c.i.: 56 to 392)
+flesh-footed shearwater captures in the same fisheries and period.
 
-During the 2020–21 and 2021–22 fishing years, there were 257 seabird captures reported by fishers frombottom longline fishing within FMA 1. Of these captures, 218 were reported from vessels participatingin the video monitoring trial and only 39 seabird captures were reported from other vessels. The rate offisher reported seabird captures was close to ten times higher on vessels that were participating in thepetrel project.
+During the 2020–21 and 2021–22 fishing years, there were 257 seabird captures reported by fishers from 
+bottom longline fishing within FMA 1. Of these captures, 218 were reported from vessels participating 
+in the video monitoring trial and only 39 seabird captures were reported from other vessels. The rate of 
+fisher reported seabird captures was close to ten times higher on vessels that were participating in the 
+petrel project. 

--- a/content/publications/rose_advancing_2024.md
+++ b/content/publications/rose_advancing_2024.md
@@ -6,13 +6,13 @@ Climate change has rapidly altered marine ecosystems and is expected to continue
 push systems and species beyond historical baselines into novel conditions. Projecting responses of 
 organisms and populations to these novel environmental conditions often requires extrapolations 
 beyond observed conditions, challenging the predictive limits of statistical modeling capabilities. 
-Bioenergetics modeling provides the mechanistic basis for projecting climate change effects on  
+Bioenergetics modeling provides the mechanistic basis for projecting climate change effects on 
 marine living resources in novel conditions, has a long history of development, and has been applied 
 widely to fish and other taxa.  
 
 We provide our perspective on 4 opportunities that will advance the 
 ability of bioenergetics-based models to depict changes in the productivity and distribution of fishes 
-and other marine organisms, leading to more robust projections of climate impacts. These are (1)  
+and other marine organisms, leading to more robust projections of climate impacts. These are (1) 
 improved depiction of bioenergetics processes to derive realistic individual-level response(s) to  
 complex changes in environmental conditions, (2) innovations in scaling individual-level bioenergetics 
 to project responses at the population and food web levels, (3) more realistic coupling between 

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -100,7 +100,7 @@
     "eslint": "eslint \"./src/js/**/*.ts\"",
     "eslint:check": "eslint --print-config \"./src/js/**/*.ts\" | eslint-config-prettier-check",
     "eslint:fix": "eslint --fix \"./src/js/**/*.ts\"",
-    "fonts": "mkdir -p ../content/fonts & glyphs2font fonts.yaml",
+    "fonts": "pwd & mkdir -p ../content/fonts & ls -al ../content/fonts & glyphs2font fonts.yaml",
     "postfonts": "mkdir -p ../_site/fonts && postcss ../content/fonts/dragonfly.css --env production --no-map -o ../_site/fonts/dragonfly.css",
     "imagemin": "chmod -R 775 ../_site && node imagemin.js",
     "prettier:fix": "prettier --write \"./src/js/**/*.ts\"",


### PR DESCRIPTION
I've fixed (hopefully) the run-in text in the summaries of the newly-added publications. Building fine on UAT (thanks again @simon). 